### PR TITLE
feat(driver): implement driver for evdev

### DIFF
--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -9,18 +9,14 @@ pub trait Device {
 /// Describes a physical keyboard device.
 pub struct Keyboard {
     path: String,
+    name: String,
 }
 
 impl Keyboard {
-    pub fn new<T: Into<String>>(path: T) -> Self {
-        Self { path: path.into() }
-    }
-}
-
-impl From<&str> for Keyboard {
-    fn from(path: &str) -> Self {
+    pub fn new<T: Into<String>>(name: T, path: T) -> Self {
         Self {
-            path: path.to_string(),
+            name: name.into(),
+            path: path.into(),
         }
     }
 }
@@ -50,7 +46,7 @@ pub enum Status {
     Hold,
 }
 
-/// Describes a Key event and its status that occurs at a certain point in time.
+/// Describes an input event and its status that occurs at a certain point in time.
 pub struct InputFragment<T: Device> {
     key: Key<T>,
     status: Status,
@@ -67,7 +63,7 @@ impl<T: Device> InputFragment<T> {
     }
 }
 
-/// A Collection of InputFragments.
+/// A Collection of `InputFragments`.
 pub struct FragmentBundle<'a, T: 'a + Device> {
     fragments: Vec<&'a InputFragment<T>>,
 }

--- a/src/driver/evdev/mod.rs
+++ b/src/driver/evdev/mod.rs
@@ -2,6 +2,7 @@ use crate::device::{Device, Keyboard};
 
 use super::{Driver, Error};
 
+/// Evdev is a wrapper around the evdev library.
 pub struct Evdev {}
 
 impl Evdev {
@@ -9,8 +10,9 @@ impl Evdev {
         Self {}
     }
 }
-
 impl Driver for Evdev {
+    /// Crawls `/dev/input` for evdev devices.
+    /// If name of device can't be read, will use "N/A".
     fn get_devices(&self) -> Result<Vec<Box<dyn Device>>, Error> {
         Ok(evdev::enumerate()
             .filter(|(_, d)| d.physical_path().is_some())

--- a/src/driver/evdev/mod.rs
+++ b/src/driver/evdev/mod.rs
@@ -1,3 +1,5 @@
+use crate::device::{Device, Keyboard};
+
 use super::Driver;
 
 pub struct Evdev {}
@@ -9,19 +11,17 @@ impl Evdev {
 }
 
 impl Driver for Evdev {
-    fn get_devices(&self) -> Result<Vec<Box<dyn crate::device::Device>>, super::Error> {
-        // evdev::enumerate()
-        //     .filter_map(|(_, device)| {
-        //         if let Some(path) = device.physical_path() {
-        //             let name = device.name().unwrap_or("N/A");
-        //             return Some(Keyboard::new(path) {
-        //                 // name: name.to_string(),
-        //                 // path: path.to_string(),
-        //             });
-        //         }
-        //         None
-        //     })
-        //     .collect()
-        todo!()
+    fn get_devices(&self) -> Result<Vec<Box<dyn Device>>, super::Error> {
+        let devices = evdev::enumerate().map(|t| t.1).collect::<Vec<_>>();
+        let mut vec: Vec<Box<dyn Device>> = vec![];
+
+        for d in devices {
+            if let Some(path) = d.physical_path() {
+                let name = d.name().unwrap_or("N/a");
+                vec.push(Box::new(Keyboard::new(name, path)));
+            }
+        }
+
+        Ok(vec)
     }
 }

--- a/src/driver/evdev/mod.rs
+++ b/src/driver/evdev/mod.rs
@@ -1,6 +1,6 @@
 use crate::device::{Device, Keyboard};
 
-use super::Driver;
+use super::{Driver, Error};
 
 pub struct Evdev {}
 
@@ -11,17 +11,14 @@ impl Evdev {
 }
 
 impl Driver for Evdev {
-    fn get_devices(&self) -> Result<Vec<Box<dyn Device>>, super::Error> {
-        let devices = evdev::enumerate().map(|t| t.1).collect::<Vec<_>>();
-        let mut vec: Vec<Box<dyn Device>> = vec![];
-
-        for d in devices {
-            if let Some(path) = d.physical_path() {
-                let name = d.name().unwrap_or("N/a");
-                vec.push(Box::new(Keyboard::new(name, path)));
-            }
-        }
-
-        Ok(vec)
+    fn get_devices(&self) -> Result<Vec<Box<dyn Device>>, Error> {
+        Ok(evdev::enumerate()
+            .filter(|(_, d)| d.physical_path().is_some())
+            .map(|(_, d)| -> Box<dyn Device> {
+                let name = d.name().unwrap_or("N/A");
+                let path = d.physical_path().unwrap();
+                Box::new(Keyboard::new(name, path))
+            })
+            .collect())
     }
 }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -7,5 +7,6 @@ enum Error {
 }
 
 trait Driver {
+    /// Returns a list of available devices.
     fn get_devices(&self) -> Result<Vec<Box<dyn Device>>, Error>;
 }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,8 +1,6 @@
 mod evdev;
 
-use ::evdev::Key;
-
-use crate::device::{Device, Keyboard};
+use crate::device::Device;
 
 enum Error {
     Unknown,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+#![warn(clippy::pedantic)]
+#![allow(dead_code)]
+
 mod device;
 mod driver;
 


### PR DESCRIPTION
Implements Driver trait for Evdev struct.

We might need to rename `Evdev` struct and module name because of high collision chance with the `evdev` crate.