### PR TITLE
feat(driver): default get_printable_devices

### DIFF
--- a/src/driver/evdev/mod.rs
+++ b/src/driver/evdev/mod.rs
@@ -26,10 +26,10 @@ impl Driver for Evdev {
 
     /// Print devices' name and path if found.
     fn print_devices(&self) {
-        match self.get_devices() {
+        match self.get_printable_devices() {
             Ok(devices) => {
-                for d in devices {
-                    println!("Device {} at {}", d.name(), d.path());
+                for (name, path) in devices {
+                    println!("Device {} at {}", name, path);
                 }
             }
             Err(error) => {

--- a/src/driver/evdev/mod.rs
+++ b/src/driver/evdev/mod.rs
@@ -28,12 +28,8 @@ impl Driver for Evdev {
     fn print_devices(&self) {
         match self.get_devices() {
             Ok(devices) => {
-                if devices.is_empty() {
-                    println!("No devices found");
-                } else {
-                    for d in devices {
-                        println!("Device {} at {}", d.name(), d.path());
-                    }
+                for d in devices {
+                    println!("Device {} at {}", d.name(), d.path());
                 }
             }
             Err(error) => {

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -7,6 +7,7 @@ use crate::device::Keyboard;
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     Unknown,
+    NoDevicesFound,
 }
 
 #[cfg(test)]
@@ -16,6 +17,22 @@ use mockall::automock;
 pub trait Driver {
     fn get_devices(&self) -> Result<Vec<Box<dyn Device>>, Error>;
     fn print_devices(&self);
+
+    fn get_printable_devices(&self) -> Result<Vec<(String, String)>, Error> {
+        match self.get_devices() {
+            Ok(devices) => {
+                if devices.is_empty() {
+                    Err(Error::NoDevicesFound)
+                } else {
+                    Ok(devices
+                        .iter()
+                        .map(|d| (d.name().to_string(), d.path().to_string()))
+                        .collect())
+                }
+            }
+            Err(error) => Err(error),
+        }
+    }
 }
 
 pub fn get_devices<T: Driver>(driver: &T) -> Result<Vec<Box<dyn Device>>, Error> {


### PR DESCRIPTION
Adds default implementation of Driver's
get_printable_devices method.

Ref #16, #20